### PR TITLE
Allow method="pearson" for corr_case and corr_pair

### DIFF
--- a/researchpy/correlation.py
+++ b/researchpy/correlation.py
@@ -13,7 +13,7 @@ import itertools
 
 
 
-def corr_case(dataframe, method = None):
+def corr_case(dataframe, method = "pearson"):
     
     df = dataframe.dropna(how = 'any')._get_numeric_data()
     dfcols = pandas.DataFrame(columns= df.columns)
@@ -26,7 +26,7 @@ def corr_case(dataframe, method = None):
     
     
     # Setting test
-    if method == None:
+    if method in (None, "pearson"):
         test = scipy.stats.pearsonr
         test_name = "Pearson"
         
@@ -37,6 +37,9 @@ def corr_case(dataframe, method = None):
     elif method == "kendall":
         test = scipy. stats.kendalltau
         test_name = "Kendall's Tau-b"
+
+    else:
+        raise ValueError("Unknown method: " + method)
         
         
     # Rounding values for the r and p value dataframes 
@@ -63,7 +66,7 @@ def corr_case(dataframe, method = None):
 
 
 
-def corr_pair(dataframe, method= None):
+def corr_pair(dataframe, method= "pearson"):
     
     df = dataframe
     
@@ -74,7 +77,7 @@ def corr_pair(dataframe, method= None):
     
     
     # Setting test
-    if method == None:
+    if method in (None, "pearson"):
         test = scipy.stats.pearsonr
         test_name = "Pearson"
         
@@ -85,6 +88,9 @@ def corr_pair(dataframe, method= None):
     elif method == "kendall":
         test = scipy.stats.kendalltau
         test_name = "Kendall's Tau-b"
+
+    else:
+        raise ValueError("Unknown method: " + method)
     
     
     # Iterrating through the Pandas series and performing the correlation

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ Last updated: 02/18/2019
 from setuptools import setup
 
 setup(name= "researchpy",
-      version= "0.1.8",
+      version= "0.1.9",
       description= "researchpy produces Pandas DataFrames that contain relevant statistical testing information that is commonly required for academic research.",
       long_description= "researchpy produces Pandas DataFrames that contain relevant statistical testing information that is commonly required for academic research. The information is returned as Pandas DataFrames to make for quick and easy exporting of results to any format/method that works with the traditional Pandas DataFrame. researchpy is essentially a wrapper that combines various established packages such as pandas, scipy.stats, and statsmodels to get all the standard required information in one method. If analyses were not available in these packages, code was developed to fill the gap.",
       url= "http://researchpy.readthedocs.io/",


### PR DESCRIPTION
At current corr_(case|pair)(df, method="pearson") fails even though it a
supported algorithm. This enables it to be defined as well as supporting
the previous "None" value. It also gives a better error message if an
unknown method name is given.